### PR TITLE
chore: add repository metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "fedimint-http"
 version = "0.1.5"
 edition = "2021"
 description = "HTTP server for Fedimint Client, exposing REST and Websocket APIs for default modules."
+repository = "https://github.com/Kodylow/fedimint-http/"
+keywords = ["fedimint", "fedimint-cli"]
 license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The repository link is not being displayed on crates.io because the `repository` field is missing in the Cargo.toml file.
If this is intended, feel free to close the PR and reject the changes.


refs:
https://crates.io/crates/fedimint-http
https://doc.rust-lang.org/cargo/reference/publishing.html#before-publishing-a-new-crate

