### PR TITLE
chore: reorganize routes middlewares

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -114,14 +114,14 @@ async fn main() -> Result<()> {
         .with_service_name("fedimint-http".to_string())
         .build();
 
-    // add routes for the readme and status
     let app = app
-        .route("/", get(handle_readme))
-        .merge(metrics.routes())
-        .layer(metrics)
-        .layer(TraceLayer::new_for_http())
         .layer(cors)
-        .route("/health", get(handle_status)); // health check should not be traced, adding it after the trace layer
+        .layer(TraceLayer::new_for_http()) // tracing requests
+        // no traces for routes bellow
+        .route("/health", get(|| async { "Server is up and running!" })) // for health check
+        // metrics for all routes above
+        .merge(metrics.routes())
+        .layer(metrics);
 
     let listener = tokio::net::TcpListener::bind(format!("{}:{}", &cli.domain, &cli.port))
         .await

--- a/src/router/handlers/mod.rs
+++ b/src/router/handlers/mod.rs
@@ -1,17 +1,2 @@
 pub mod cashu;
 pub mod fedimint;
-
-use std::fs::read_to_string;
-
-use axum::Json;
-use serde_json::{json, Value};
-
-#[axum_macros::debug_handler]
-pub async fn handle_readme() -> String {
-    read_to_string("README.md").expect("Could not read README.md")
-}
-
-#[axum_macros::debug_handler]
-pub async fn handle_status() -> Json<Value> {
-    Json(json!({"status": "ok"}))
-}


### PR DESCRIPTION
1. should trace important routes
2. should NOT trace health check
3. should have metrics for all routes